### PR TITLE
Added version 9 and encryption support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 /tmp
 *.zip
 *.exe
-*.pak
 .*
 /perf.data
 /perf.data.old

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aes"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "495ee669413bfbe9e8cace80f4d3d78e6d8c8d99579f97fb93bde351b185f2d4"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+ "opaque-debug",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,6 +45,12 @@ name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bitflags"
@@ -69,6 +87,15 @@ dependencies = [
  "num-traits",
  "time",
  "winapi",
+]
+
+[[package]]
+name = "cipher"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -111,6 +138,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfb0da5a62f5c9c384041af4d81ab52c19b0064663d0b5b6626393af20c224f9"
 dependencies = [
  "pkg-config",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -181,6 +217,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "generic-array"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,9 +254,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.94"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
+checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
 
 [[package]]
 name = "log"
@@ -256,6 +313,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
 name = "openssl"
 version = "0.10.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,15 +333,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl-src"
-version = "111.15.0+1.1.1k"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a5f6ae2ac04393b217ea9f700cd04fa9bf3d93fae2872069f3d15d908af70a"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,7 +341,6 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -299,10 +352,88 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "rand"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "tempfile"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rand",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
 
 [[package]]
 name = "terminal_size"
@@ -335,9 +466,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
+
+[[package]]
 name = "u4pak"
 version = "1.3.0"
 dependencies = [
+ "aes",
+ "base64",
  "chrono",
  "clap",
  "cntr-fuse",
@@ -348,6 +487,7 @@ dependencies = [
  "libc",
  "num_cpus",
  "openssl",
+ "tempfile",
  "terminal_size",
 ]
 
@@ -368,6 +508,12 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "version_check"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,17 +227,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
 name = "hermit-abi"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,88 +341,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
-
-[[package]]
-name = "rand"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
-dependencies = [
- "getrandom",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "tempfile"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
-dependencies = [
- "cfg-if",
- "libc",
- "rand",
- "redox_syscall",
- "remove_dir_all",
- "winapi",
-]
 
 [[package]]
 name = "terminal_size"
@@ -487,7 +398,6 @@ dependencies = [
  "libc",
  "num_cpus",
  "openssl",
- "tempfile",
  "terminal_size",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ num_cpus = "1.0"
 # OpenSSL's SHA-1 implementation is much faster than the one in rust-crypto
 openssl = { version = "0.10", features = ["vendored"] }
 terminal_size = "0.1.16"
+aes = "0.7.4"
+base64 = "0.13.0"
+tempfile = "3.2.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # for sendfile() and fuse support

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ openssl = { version = "0.10", features = ["vendored"] }
 terminal_size = "0.1.16"
 aes = "0.7.4"
 base64 = "0.13.0"
-tempfile = "3.2.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # for sendfile() and fuse support

--- a/src/check.rs
+++ b/src/check.rs
@@ -322,13 +322,13 @@ pub fn check<'a>(pak: &'a Pak, in_file: &mut File, options: CheckOptions) -> Res
         drop(result_sender);
 
         if let Some(filter) = &mut filter {
-            let records = pak.records()
+            let records = pak.index().records()
                 .iter()
                 .filter(|&record| filter.visit(record.filename()));
 
             error_count += enqueue(records, work_sender, abort_on_error, null_separated)?;
         } else {
-            error_count += enqueue(pak.records().iter(), work_sender, abort_on_error, null_separated)?;
+            error_count += enqueue(pak.index().records().iter(), work_sender, abort_on_error, null_separated)?;
         }
 
         let linesep = if options.null_separated { '\0' } else { '\n' };

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -78,7 +78,7 @@ impl Decode for CompressionBlock {
     #[inline]
     fn decode(reader: &mut impl Read) -> Result<Self> {
         let start_offset = u64::decode(reader)?;
-        let end_offset = u64::decode(reader)?;
+        let end_offset   = u64::decode(reader)?;
 
         Ok(Self {
             start_offset,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -21,6 +21,15 @@ pub trait Decode: Sized {
     fn decode(reader: &mut impl Read) -> Result<Self>;
 }
 
+impl Decode for bool {
+    #[inline]
+    fn decode(reader: &mut impl Read) -> Result<Self> {
+        let mut buffer = [0u8; 1];
+        reader.read_exact(&mut buffer)?;
+        Ok(buffer[0] != 0u8)
+    }
+}
+
 impl Decode for u8 {
     #[inline]
     fn decode(reader: &mut impl Read) -> Result<Self> {
@@ -38,11 +47,19 @@ impl Decode for u32 {
     }
 }
 
-
 impl Decode for u64 {
     #[inline]
     fn decode(reader: &mut impl Read) -> Result<Self> {
         let mut buffer = [0u8; 8];
+        reader.read_exact(&mut buffer)?;
+        Ok(Self::from_le_bytes(buffer))
+    }
+}
+
+impl Decode for u128 {
+    #[inline]
+    fn decode(reader: &mut impl Read) -> Result<Self> {
+        let mut buffer = [0u8; 16];
         reader.read_exact(&mut buffer)?;
         Ok(Self::from_le_bytes(buffer))
     }
@@ -61,7 +78,7 @@ impl Decode for CompressionBlock {
     #[inline]
     fn decode(reader: &mut impl Read) -> Result<Self> {
         let start_offset = u64::decode(reader)?;
-        let end_offset   = u64::decode(reader)?;
+        let end_offset = u64::decode(reader)?;
 
         Ok(Self {
             start_offset,

--- a/src/decrypt.rs
+++ b/src/decrypt.rs
@@ -1,0 +1,52 @@
+use crate::{Error, Record, Result};
+use aes::cipher::{BlockDecrypt, NewBlockCipher};
+use aes::{Aes256, Block};
+use base64;
+use std::fs::File;
+use std::io::BufReader;
+use std::io::BufWriter;
+use std::io::Read;
+use std::io::Seek;
+use std::io::Write;
+
+pub fn decrypt(data: &mut Vec<u8>, base64_key: &str) {
+    let decoded_key = base64::decode(base64_key).unwrap();
+    let cipher = Aes256::new_from_slice(&decoded_key).unwrap();
+
+    for i in 0..data.len() / 16 {
+        let mut block = Block::from_mut_slice(&mut data[i * 16..i * 16 + 16]);
+        cipher.decrypt_block(&mut block);
+    }
+}
+
+pub fn decrypt_file(
+    input: &mut File,
+    output: &mut File,
+    base64_key: &str,
+    mut length: usize,
+) -> Result<bool> {
+    let decoded_key = base64::decode(base64_key).unwrap();
+    let cipher = Aes256::new_from_slice(&decoded_key).unwrap();
+
+    let mut buf_reader = BufReader::new(input);
+    let mut buf_writer = BufWriter::new(output);
+
+    length = length
+        + if length % 16 != 0 {
+            16 - length % 16
+        } else {
+            0
+        };
+    for _ in 0..length / 16 {
+        let block_buf = &mut [0u8; 16];
+        buf_reader.read_exact(block_buf)?;
+
+        let mut block = Block::from_mut_slice(block_buf);
+        cipher.decrypt_block(&mut block);
+
+        buf_writer.write(block_buf)?;
+    }
+    buf_writer.flush()?;
+
+    Ok(true)
+}

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,0 +1,170 @@
+use crate::decode;
+use crate::decode::Decode;
+use crate::decrypt::decrypt;
+use crate::Variant;
+use crate::{Error, Record, Result};
+
+use std::convert::TryFrom;
+use std::io::Cursor;
+use std::io::Read;
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum Encoding {
+    ASCII,
+    Latin1,
+    UTF8,
+}
+
+impl Default for Encoding {
+    fn default() -> Self {
+        Encoding::UTF8
+    }
+}
+
+impl Encoding {
+    pub fn parse_vec(self, buffer: Vec<u8>) -> Result<String> {
+        match self {
+            Encoding::UTF8 => Ok(String::from_utf8(buffer)?),
+            Encoding::ASCII => {
+                for byte in &buffer {
+                    if *byte > 0x7F {
+                        return Err(Error::new(format!(
+                            "ASCII conversion error: byte outside of ASCII range: {}",
+                            *byte
+                        )));
+                    }
+                }
+                Ok(buffer.into_iter().map(|byte| byte as char).collect())
+            }
+            Encoding::Latin1 => Ok(buffer.into_iter().map(|byte| byte as char).collect()),
+        }
+    }
+}
+
+impl TryFrom<&str> for Encoding {
+    type Error = crate::result::Error;
+
+    fn try_from(encoding: &str) -> std::result::Result<Self, Error> {
+        if encoding.eq_ignore_ascii_case("utf-8") || encoding.eq_ignore_ascii_case("utf8") {
+            Ok(Encoding::UTF8)
+        } else if encoding.eq_ignore_ascii_case("ascii") {
+            Ok(Encoding::ASCII)
+        } else if encoding.eq_ignore_ascii_case("latin1")
+            || encoding.eq_ignore_ascii_case("iso-8859-1")
+        {
+            Ok(Encoding::Latin1)
+        } else {
+            Err(Error::new(format!("unsupported encoding: {:?}", encoding)))
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Index {
+    pub mount_point: Result<String>,
+    pub records: Vec<Record>,
+}
+
+impl Index {
+    pub(crate) fn new(mount_point: Result<String>, records: Vec<Record>) -> Self {
+        Self {
+            mount_point,
+            records,
+        }
+    }
+    pub fn read(
+        data: &mut Vec<u8>,
+        version: u32,
+        variant: Variant,
+        encoding: Encoding,
+        encryption_key: Option<&str>,
+    ) -> Self {
+        if encryption_key.is_some() {
+            decrypt(data, encryption_key.unwrap());
+        }
+
+        let decrypted_index = &mut Cursor::new(data);
+
+        let mount_point = read_path(decrypted_index, encoding);
+        let records = read_records(decrypted_index, version, variant, encoding)
+            .expect("Failed to read index records");
+
+        Self {
+            mount_point,
+            records,
+        }
+    }
+}
+
+pub fn read_path(reader: &mut impl Read, encoding: Encoding) -> Result<String> {
+    let mut buf = [0; 4];
+    reader.read_exact(&mut buf)?;
+    let size = i32::from_le_bytes(buf);
+
+    if size < 0 {
+        let utf16_size = -(size as isize) as usize;
+        let mut buf = vec![0u8; 2 * utf16_size];
+        reader.read_exact(&mut buf)?;
+
+        let mut utf16 = Vec::with_capacity(utf16_size);
+        let mut index = 0usize;
+        while index < buf.len() {
+            let bytes = [buf[index], buf[index + 1]];
+            utf16.push(u16::from_le_bytes(bytes));
+            index += 2;
+        }
+
+        if let Some(index) = utf16.iter().position(|&ch| ch == 0) {
+            utf16.truncate(index);
+        }
+
+        return Ok(String::from_utf16(&utf16)?);
+    }
+
+    let mut buf = vec![0u8; size as usize];
+    reader.read_exact(&mut buf)?;
+    if let Some(index) = buf.iter().position(|&byte| byte == 0) {
+        buf.truncate(index);
+    }
+
+    encoding.parse_vec(buf)
+}
+
+pub fn read_records(
+    reader: &mut impl Read,
+    version: u32,
+    variant: Variant,
+    encoding: Encoding,
+) -> Result<Vec<Record>> {
+    let read_record = match variant {
+        Variant::ConanExiles => {
+            if version != 4 {
+                return Err(Error::new(format!(
+                    "Only know how to handle Conan Exile paks of version 4, but version was {}.",
+                    version
+                )));
+            }
+            Record::read_conan_exiles
+        }
+        Variant::Standard => match version {
+            1 => Record::read_v1,
+            2 => Record::read_v2,
+            _ if version <= 5 || version == 7 || version == 9 => Record::read_v3,
+            _ => {
+                return Err(Error::new(format!("unsupported version: {}", version)));
+            }
+        },
+    };
+
+    decode!(reader, entry_count: u32);
+
+    let mut records = Vec::with_capacity(entry_count as usize);
+
+    for _ in 0..entry_count {
+        let filename = read_path(reader, encoding)?;
+        let record = read_record(reader, filename)?;
+        records.push(record);
+    }
+
+    Ok(records)
+}

--- a/src/info.rs
+++ b/src/info.rs
@@ -45,7 +45,7 @@ pub fn info(pak: &Pak, human_readable: bool) -> Result<()> {
     let mut sum_uncompr_unknown_size     = 0;
     let mut sum_uncompr_encrypted_size   = 0;
 
-    for record in pak.records() {
+    for record in pak.index().records() {
         sum_size += record.size();
         sum_uncompressed_size += record.uncompressed_size();
         if record.encrypted() {
@@ -82,14 +82,14 @@ pub fn info(pak: &Pak, human_readable: bool) -> Result<()> {
     }
 
     println!("Pak Version: {}", pak.version());
-    println!("Mount Point: {}", pak.mount_point().unwrap_or(""));
+    println!("Mount Point: {}", pak.index().mount_point().unwrap_or(""));
     println!();
 
     print_table(
         &["", "Count", "Size", "Uncompr."],
         &[Align::Left, Align::Right, Align::Right, Align::Right],
         &[
-            vec!["Files:",              &format!("{}", pak.records().len()), &fmt_size(sum_size),             &fmt_size(sum_uncompressed_size)],
+            vec!["Files:",              &format!("{}", pak.index().records().len()), &fmt_size(sum_size),             &fmt_size(sum_uncompressed_size)],
             vec!["Uncompr.:",           &format!("{}", uncompr_count),       &fmt_size(sum_uncompr_size),     ""],
             vec!["ZLIB Compr.:",        &format!("{}", zlib_count),          &fmt_size(sum_zlib_size),        &fmt_size(sum_uncompr_zlib_size)],
             vec!["Bias Speed Compr.:",  &format!("{}", bias_speed_count),    &fmt_size(sum_bias_speed_size),  &fmt_size(sum_uncompr_bias_speed_size)],

--- a/src/list.rs
+++ b/src/list.rs
@@ -65,7 +65,7 @@ pub fn list(pak: Pak, options: ListOptions) -> Result<()> {
     match (options.order, options.paths) {
         (Some(order), Some(paths)) => {
             let mut filter = Filter::from_paths(paths.iter().cloned());
-            let mut records = pak.records()
+            let mut records = pak.index().records()
                 .iter()
                 .filter(|record| filter.visit(record.filename()))
                 .collect();
@@ -75,14 +75,14 @@ pub fn list(pak: Pak, options: ListOptions) -> Result<()> {
             filter.assert_all_visited()?;
         }
         (Some(order), None) => {
-            let mut records = pak.into_records();
+            let mut records = pak.index().records().iter().collect();
 
             sort(&mut records, order);
             list_records(version, &records, options)?;
         }
         (None, Some(paths)) => {
             let mut filter = Filter::from_paths(paths.iter().cloned());
-            let records = pak.records()
+            let records = pak.index().records()
                 .iter()
                 .filter(|record| filter.visit(record.filename()))
                 .collect::<Vec<_>>();
@@ -91,7 +91,7 @@ pub fn list(pak: Pak, options: ListOptions) -> Result<()> {
             filter.assert_all_visited()?;
         }
         (None, None) => {
-            list_records(version, pak.records(), options)?;
+            list_records(version, pak.index().records(), options)?;
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,9 @@ use std::convert::TryFrom;
 pub mod pak;
 pub use pak::{Pak, Options, COMPR_ZLIB};
 
+pub mod decrypt;
+pub mod index;
+
 pub mod result;
 pub use result::{Error, Result};
 
@@ -242,6 +245,15 @@ fn arg_print0<'a, 'b>() -> Arg<'a, 'b> {
             file name separators.")
 }
 
+fn arg_encryption_key<'a, 'b>() -> Arg<'a, 'b> {
+    Arg::with_name("encryption-key")
+        .long("encryption-key")
+        .short("k")
+        .takes_value(true)
+        .value_name("ENCRYPTION_KEY")
+        .help("Base64 encoded 16 byte AES encryption key")
+}
+
 #[cfg(target_family="windows")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Pause {
@@ -354,7 +366,8 @@ fn make_app<'a, 'b>() -> App<'a, 'b> {
             .arg(arg_ignore_magic())
             .arg(arg_encoding())
             .arg(arg_force_version())
-            .arg(arg_package()))
+            .arg(arg_package())
+            .arg(arg_encryption_key()))
         .subcommand(SubCommand::with_name("list")
             .alias("l")
             .about("List content of a package")
@@ -400,7 +413,8 @@ fn make_app<'a, 'b>() -> App<'a, 'b> {
             .arg(arg_human_readable())
             .arg(arg_threads())
             .arg(arg_package())
-            .arg(arg_paths()))
+            .arg(arg_paths())
+            .arg(arg_encryption_key()))
         .subcommand(SubCommand::with_name("check")
             .alias("c")
             .about("Check consistency of a package")
@@ -417,7 +431,8 @@ fn make_app<'a, 'b>() -> App<'a, 'b> {
             .arg(arg_threads())
             .arg(arg_verbose())
             .arg(arg_package())
-            .arg(arg_paths()))
+            .arg(arg_paths())
+            .arg(arg_encryption_key()))
         .subcommand(SubCommand::with_name("unpack")
             .alias("u")
             .about("Unpack content of a package")
@@ -443,7 +458,8 @@ fn make_app<'a, 'b>() -> App<'a, 'b> {
                 .default_value(".")
                 .help("Write unpacked files to DIR."))
             .arg(arg_package())
-            .arg(arg_paths()))
+            .arg(arg_paths())
+            .arg(arg_encryption_key()))
         .subcommand(SubCommand::with_name("pack")
             .alias("p")
             .about("Create a new package")
@@ -620,11 +636,21 @@ fn run(matches: &ArgMatches) -> Result<()> {
                 None
             };
 
+            let encryption_key = if let Some(key) = args.value_of("encryption-key") {
+                Some(
+                    key.parse::<String>()
+                        .expect("Failed to parse encryption key."),
+                )
+            } else {
+                None
+            };
+
             let pak = Pak::from_path(&path, Options {
                 variant,
                 ignore_magic,
                 encoding,
                 force_version,
+                encryption_key: encryption_key.as_ref().and_then(|key| Some(key.as_str())),
             })?;
 
             info(&pak, human_readable)?;
@@ -658,6 +684,15 @@ fn run(matches: &ArgMatches) -> Result<()> {
                 None
             };
 
+            let encryption_key = if let Some(key) = args.value_of("encryption-key") {
+                Some(
+                    key.parse::<String>()
+                        .expect("Failed to parse encryption key."),
+                )
+            } else {
+                None
+            };
+
             let mut file = match File::open(path) {
                 Ok(file) => file,
                 Err(error) => return Err(Error::io_with_path(error, path))
@@ -669,6 +704,7 @@ fn run(matches: &ArgMatches) -> Result<()> {
                 ignore_magic,
                 encoding,
                 force_version,
+                encryption_key: encryption_key.as_ref().and_then(|key| Some(key.as_str())),
             })?;
 
             drop(reader);
@@ -705,6 +741,15 @@ fn run(matches: &ArgMatches) -> Result<()> {
                 None
             };
 
+            let encryption_key = if let Some(key) = args.value_of("encryption-key") {
+                Some(
+                    key.parse::<String>()
+                        .expect("Failed to parse encryption key."),
+                )
+            } else {
+                None
+            };
+
             let mut file = match File::open(path) {
                 Ok(file) => file,
                 Err(error) => return Err(Error::io_with_path(error, path))
@@ -716,6 +761,7 @@ fn run(matches: &ArgMatches) -> Result<()> {
                 ignore_magic,
                 encoding,
                 force_version,
+                encryption_key: encryption_key.as_ref().and_then(|key| Some(key.as_str())),
             })?;
 
             let options = CheckOptions {
@@ -761,6 +807,15 @@ fn run(matches: &ArgMatches) -> Result<()> {
                 None
             };
 
+            let encryption_key = if let Some(key) = args.value_of("encryption-key") {
+                Some(
+                    key.parse::<String>()
+                        .expect("Failed to parse encryption key."),
+                )
+            } else {
+                None
+            };
+
             let mut file = match File::open(path) {
                 Ok(file) => file,
                 Err(error) => return Err(Error::io_with_path(error, path))
@@ -772,6 +827,7 @@ fn run(matches: &ArgMatches) -> Result<()> {
                 ignore_magic,
                 encoding,
                 force_version,
+                encryption_key: encryption_key.as_ref().and_then(|key| Some(key.as_str())),
             })?;
 
             drop(reader);
@@ -782,6 +838,7 @@ fn run(matches: &ArgMatches) -> Result<()> {
                 null_separated,
                 paths,
                 thread_count,
+                encryption_key: encryption_key.as_ref().and_then(|key| Some(key.as_str())),
             })?;
         }
         ("pack", Some(args)) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -638,7 +638,7 @@ fn run(matches: &ArgMatches) -> Result<()> {
 
             let encryption_key = if let Some(key) = args.value_of("encryption-key") {
                 Some(
-                    key.parse::<String>()
+                    base64::decode(key.parse::<String>().expect("Failed to read encryption key."))
                         .expect("Failed to parse encryption key."),
                 )
             } else {
@@ -650,7 +650,7 @@ fn run(matches: &ArgMatches) -> Result<()> {
                 ignore_magic,
                 encoding,
                 force_version,
-                encryption_key: encryption_key.as_ref().and_then(|key| Some(key.as_str())),
+                encryption_key
             })?;
 
             info(&pak, human_readable)?;
@@ -686,7 +686,7 @@ fn run(matches: &ArgMatches) -> Result<()> {
 
             let encryption_key = if let Some(key) = args.value_of("encryption-key") {
                 Some(
-                    key.parse::<String>()
+                    base64::decode(key.parse::<String>().expect("Failed to read encryption key."))
                         .expect("Failed to parse encryption key."),
                 )
             } else {
@@ -704,7 +704,7 @@ fn run(matches: &ArgMatches) -> Result<()> {
                 ignore_magic,
                 encoding,
                 force_version,
-                encryption_key: encryption_key.as_ref().and_then(|key| Some(key.as_str())),
+                encryption_key
             })?;
 
             drop(reader);
@@ -743,7 +743,7 @@ fn run(matches: &ArgMatches) -> Result<()> {
 
             let encryption_key = if let Some(key) = args.value_of("encryption-key") {
                 Some(
-                    key.parse::<String>()
+                    base64::decode(key.parse::<String>().expect("Failed to read encryption key."))
                         .expect("Failed to parse encryption key."),
                 )
             } else {
@@ -761,7 +761,7 @@ fn run(matches: &ArgMatches) -> Result<()> {
                 ignore_magic,
                 encoding,
                 force_version,
-                encryption_key: encryption_key.as_ref().and_then(|key| Some(key.as_str())),
+                encryption_key
             })?;
 
             let options = CheckOptions {
@@ -809,7 +809,7 @@ fn run(matches: &ArgMatches) -> Result<()> {
 
             let encryption_key = if let Some(key) = args.value_of("encryption-key") {
                 Some(
-                    key.parse::<String>()
+                    base64::decode(key.parse::<String>().expect("Failed to read encryption key."))
                         .expect("Failed to parse encryption key."),
                 )
             } else {
@@ -827,7 +827,7 @@ fn run(matches: &ArgMatches) -> Result<()> {
                 ignore_magic,
                 encoding,
                 force_version,
-                encryption_key: encryption_key.as_ref().and_then(|key| Some(key.as_str())),
+                encryption_key: encryption_key.clone()
             })?;
 
             drop(reader);
@@ -838,7 +838,7 @@ fn run(matches: &ArgMatches) -> Result<()> {
                 null_separated,
                 paths,
                 thread_count,
-                encryption_key: encryption_key.as_ref().and_then(|key| Some(key.as_str())),
+                encryption_key
             })?;
         }
         ("pack", Some(args)) => {

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -21,7 +21,7 @@ use crossbeam_utils::thread;
 use openssl::sha::Sha1 as OpenSSLSha1;
 use flate2::{Compression, write::ZlibEncoder};
 
-use crate::{Result, pak::{BUFFER_SIZE, COMPRESSION_BLOCK_HEADER_SIZE, CONAN_EXILE_RECORD_HEADER_SIZE, DEFAULT_COMPRESSION_LEVEL, Encoding, V1_RECORD_HEADER_SIZE, V2_RECORD_HEADER_SIZE, V3_RECORD_HEADER_SIZE, Variant}, parse_compression_level, record::CompressionBlock, util::{parse_pak_path, parse_size}, walkdir::walkdir};
+use crate::{Result, pak::{BUFFER_SIZE, COMPRESSION_BLOCK_HEADER_SIZE, CONAN_EXILE_RECORD_HEADER_SIZE, DEFAULT_COMPRESSION_LEVEL, V1_RECORD_HEADER_SIZE, V2_RECORD_HEADER_SIZE, V3_RECORD_HEADER_SIZE, Variant}, parse_compression_level, record::CompressionBlock, util::{parse_pak_path, parse_size}, walkdir::walkdir};
 use crate::Pak;
 use crate::result::Error;
 use crate::pak::{PAK_MAGIC, Sha1, COMPR_NONE, COMPR_ZLIB, DEFAULT_BLOCK_SIZE, compression_method_name};
@@ -29,6 +29,8 @@ use crate::record::Record;
 use crate::util::make_pak_path;
 use crate::encode;
 use crate::encode::Encode;
+use crate::index::Encoding;
+use crate::index::Index;
 
 pub const COMPR_DEFAULT: u32 = u32::MAX;
 
@@ -436,14 +438,21 @@ pub fn pack(pak_path: impl AsRef<Path>, paths: &[PackPath], options: PackOptions
     );
     writer.flush()?;
 
+    let index = Index::new(
+        options
+            .mount_point
+            .map(str::to_string)
+            .ok_or(Error::new(String::from("No mount path provided."))),
+        records,
+    );
+
     Ok(Pak::new(
         options.variant,
         options.version,
         index_offset,
         index_size,
         index_sha1,
-        options.mount_point.map(str::to_string),
-        records,
+        index,
     ))
 }
 
@@ -548,7 +557,7 @@ fn worker_proc(options: &PackOptions, work_channel: Receiver<Work>, result_chann
         let mut in_file = match File::open(&file_path) {
             Ok(file) => file,
             Err(error) => {
-                result_channel.send( Err(Error::io_with_path(error, file_path)))?;
+                result_channel.send(Err(Error::io_with_path(error, file_path)))?;
                 break;
             }
         };
@@ -556,7 +565,7 @@ fn worker_proc(options: &PackOptions, work_channel: Receiver<Work>, result_chann
         let metadata = match in_file.metadata() {
             Ok(metadata) => metadata,
             Err(error) => {
-                result_channel.send( Err(Error::io_with_path(error, file_path)))?;
+                result_channel.send(Err(Error::io_with_path(error, file_path)))?;
                 break;
             }
         };
@@ -567,7 +576,7 @@ fn worker_proc(options: &PackOptions, work_channel: Receiver<Work>, result_chann
             let created = match metadata.created() {
                 Ok(created) => created,
                 Err(error) => {
-                    result_channel.send( Err(Error::io_with_path(error, file_path)))?;
+                    result_channel.send(Err(Error::io_with_path(error, file_path)))?;
                     break;
                 }
             };
@@ -723,9 +732,12 @@ fn worker_proc(options: &PackOptions, work_channel: Receiver<Work>, result_chann
                 }
             }
             _ => {
-                result_channel.send(Err(Error::new(
-                    format!("{}: unsupported compression method: {} ({})",
-                        path.filename, compression_method_name(compression_method), compression_method))))?;
+                result_channel.send(Err(Error::new(format!(
+                    "{}: unsupported compression method: {} ({})",
+                    path.filename,
+                    compression_method_name(compression_method),
+                    compression_method
+                ))))?;
                 break;
             }
         }

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -441,8 +441,7 @@ pub fn pack(pak_path: impl AsRef<Path>, paths: &[PackPath], options: PackOptions
     let index = Index::new(
         options
             .mount_point
-            .map(str::to_string)
-            .ok_or(Error::new(String::from("No mount path provided."))),
+            .map(str::to_string),
         records,
     );
 
@@ -732,12 +731,9 @@ fn worker_proc(options: &PackOptions, work_channel: Receiver<Work>, result_chann
                 }
             }
             _ => {
-                result_channel.send(Err(Error::new(format!(
-                    "{}: unsupported compression method: {} ({})",
-                    path.filename,
-                    compression_method_name(compression_method),
-                    compression_method
-                ))))?;
+                result_channel.send(Err(Error::new(
+                    format!("{}: unsupported compression method: {} ({})",
+                        path.filename, compression_method_name(compression_method), compression_method))))?;
                 break;
             }
         }


### PR DESCRIPTION
Hello,

I decided to do some work to support v9 PAK files as well as encrypted index and content.

First of all, I am relatively new to rust, so all hints would be appreciated and I can adjust it.
Also sorry for all the formatting changes. I noticed to late, that the auto formatting did a lot of changes. I decided to keep it, as it results in more readable files. I know this makes the diffs harder to read. Apologies for that.

Things done in this PR:
- Added calculation for footer size for various versions (up to 9).
- Added support for encrypted index
- Added support for encrypted files
- Added --encryption-key (-k) command line parameter
- Added version detection based on magic number

Encrypting index and files is not yet supported.
Index and file are Encrypted using aes256.

I was not able to test this on versions other than 9. But Ill do that the next days, to make sure I did not break anything.
I also created test pak files, but could not upload them, as github forks don't support lfs :/
