### PR TITLE
Fixed compressed file header for v5-v7 [Resolves #21]

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,7 +28,7 @@ jobs:
       with:
         path: |
           pak-examples/pak
-        key: ${{ runner.os }}-pak-${{ hashFiles('pak-examples/download.sh') }}
+        key: ${{ runner.os }}-pak-${{ hashFiles('pak-examples/build/download/*') }}
         restore-keys: |
           ${{ runner.os }}-pak-
 

--- a/src/pak.rs
+++ b/src/pak.rs
@@ -298,7 +298,7 @@ impl Pak {
 
                     if let Some(blocks) = &record.compression_blocks() {
                         size += blocks.len() as u64 * COMPRESSION_BLOCK_HEADER_SIZE;
-                        if version >= 8 {
+                        if version >= 5 {
                             size += 4;
                         }
                     }

--- a/tests/unpack_v5_it.rs
+++ b/tests/unpack_v5_it.rs
@@ -52,7 +52,6 @@ fn test_v5_encindex() -> Result<()> {
 }
 
 #[test]
-#[ignore]
 fn test_v5_compressed() -> Result<()> {
     let out_dir = "./v5_compressed-it";
     remove_dir_all(out_dir);
@@ -65,7 +64,6 @@ fn test_v5_compressed() -> Result<()> {
 }
 
 #[test]
-#[ignore]
 fn test_v5_compressed_encrypted() -> Result<()> {
     let out_dir = "./v5_compressed_encrypted-it";
     remove_dir_all(out_dir);
@@ -78,7 +76,6 @@ fn test_v5_compressed_encrypted() -> Result<()> {
 }
 
 #[test]
-#[ignore]
 fn test_v5_compressed_encrypted_encindex() -> Result<()> {
     let out_dir = "./v5_compressed_encrypted_encindex-it";
     remove_dir_all(out_dir);
@@ -91,7 +88,6 @@ fn test_v5_compressed_encrypted_encindex() -> Result<()> {
 }
 
 #[test]
-#[ignore]
 fn test_v5_compressed_encindex() -> Result<()> {
     let out_dir = "./v5_compressed_encindex-it";
     remove_dir_all(out_dir);

--- a/tests/unpack_v7_it.rs
+++ b/tests/unpack_v7_it.rs
@@ -52,7 +52,6 @@ fn test_v7_encindex() -> Result<()> {
 }
 
 #[test]
-#[ignore]
 fn test_v7_compressed() -> Result<()> {
     let out_dir = "./v7_compressed-it";
     remove_dir_all(out_dir);
@@ -65,7 +64,6 @@ fn test_v7_compressed() -> Result<()> {
 }
 
 #[test]
-#[ignore]
 fn test_v7_compressed_encrypted() -> Result<()> {
     let out_dir = "./v7_compressed_encrypted-it";
     remove_dir_all(out_dir);
@@ -78,7 +76,6 @@ fn test_v7_compressed_encrypted() -> Result<()> {
 }
 
 #[test]
-#[ignore]
 fn test_v7_compressed_encrypted_encindex() -> Result<()> {
     let out_dir = "./v7_compressed_encrypted_encindex-it";
     remove_dir_all(out_dir);
@@ -91,7 +88,6 @@ fn test_v7_compressed_encrypted_encindex() -> Result<()> {
 }
 
 #[test]
-#[ignore]
 fn test_v7_compressed_encindex() -> Result<()> {
     let out_dir = "./v7_compressed_encindex-it";
     remove_dir_all(out_dir);


### PR DESCRIPTION
Header size for v5 - v7 was wrong.
Also updated example files test_compressed_v<version>.pak to actually use compression.