### PR TITLE
Fixed decryption and compression for v2 - v4 pak files

### DIFF
--- a/src/decrypt.rs
+++ b/src/decrypt.rs
@@ -5,16 +5,15 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use aes::cipher::{BlockDecrypt, NewBlockCipher};
-use aes::{Aes256, Block};
+use aes::{Aes256, Block, BLOCK_SIZE};
+use log::trace;
 
-pub const BLOCK_SIZE: usize = 16;
-
-pub fn decrypt(data: &mut Vec<u8>, key: Vec<u8>) {
+pub fn decrypt(data: &mut Vec<u8>, key: &Vec<u8>) {
+    trace!("Decrypting data using aes256 with key {:?}", key);
     let cipher = Aes256::new_from_slice(&key).expect("Unable to convert key to Aes256 cipher");
-    assert_eq!(data.len() % 16, 0, "Data length must be a multiple of 16");
+    assert_eq!(data.len() % BLOCK_SIZE, 0, "Data length must be a multiple of 16");
 
     for block in data.chunks_mut(BLOCK_SIZE) {
         cipher.decrypt_block(Block::from_mut_slice(block));
     }
 }
-

--- a/src/index.rs
+++ b/src/index.rs
@@ -112,8 +112,8 @@ impl Index {
     {
         let mut index_buff = vec![0; index_size as usize];
         reader.read_exact(&mut index_buff)?;
-        if let Some(encryption_key) = encryption_key.clone() {
-            decrypt(&mut index_buff, encryption_key)
+        if let Some(encryption_key) = &encryption_key {
+            decrypt(&mut index_buff, &encryption_key);
         }
 
         let decrypted_index = &mut Cursor::new(index_buff);
@@ -296,7 +296,7 @@ fn read_secondary_index_records<R>(
     reader: &mut R,
     index_info: &SecondaryIndexInfo,
     encryption_key: Option<Vec<u8>>,
-    encoding: Encoding,
+    encoding: Encoding
 ) -> Result<Vec<Record>> where
     R: Read,
     R: Seek,
@@ -321,7 +321,7 @@ fn read_secondary_index_records<R>(
         }
 
         if let Some(key) = encryption_key {
-            decrypt(&mut full_directory_index_data, key);
+            decrypt(&mut full_directory_index_data, &key);
         }
 
         let mut index_buff = &full_directory_index_data[..];
@@ -378,7 +378,7 @@ fn read_secondary_index_records<R>(
         }
 
         if let Some(key) = encryption_key {
-            decrypt(&mut path_hash_index_data, key);
+            decrypt(&mut path_hash_index_data, &key);
         }
 
         let mut index_buff = &path_hash_index_data[..];

--- a/src/pak.rs
+++ b/src/pak.rs
@@ -17,6 +17,7 @@ use crate::index::{Encoding, Index};
 pub const BUFFER_SIZE: usize = 2 * 1024 * 1024;
 
 pub const PAK_MAGIC: u32 = 0x5A6F12E1;
+pub const PAK_RELATIVE_COMPRESSION_OFFSET_VERSION: u32 = 5;
 pub const PAK_MAX_SUPPORTED_VERSION: u32 = 11;
 
 pub const DEFAULT_BLOCK_SIZE: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(64 * 1024) };
@@ -294,12 +295,12 @@ impl Pak {
             Variant::Standard => match version {
                 1 => V1_RECORD_HEADER_SIZE,
                 2 => V2_RECORD_HEADER_SIZE,
-                _ if version <= 5 || version >= 7 => {
+                _ => {
                     let mut size: u64 = V3_RECORD_HEADER_SIZE;
 
                     if let Some(blocks) = &record.compression_blocks() {
                         size += blocks.len() as u64 * COMPRESSION_BLOCK_HEADER_SIZE;
-                        if version >= 5 {
+                        if version >= 3 {
                             size += 4;
                         }
                     }

--- a/src/record.rs
+++ b/src/record.rs
@@ -6,14 +6,13 @@
 
 use std::io::{Read, Write};
 use std::fmt::Write as FmtWrite;
+use aes::BLOCK_SIZE;
 
-use crate::{check::NULL_SHA1, pak::{COMPR_NONE, HexDisplay, Sha1}};
+use crate::{Error, Result, check::NULL_SHA1, pak::{COMPR_NONE, HexDisplay, Sha1}};
 use crate::decode;
 use crate::decode::Decode;
 use crate::encode;
 use crate::encode::Encode;
-use crate::Result;
-use crate::decrypt;
 use crate::pak::V3_RECORD_HEADER_SIZE;
 use crate::util::align;
 
@@ -217,9 +216,9 @@ impl Record {
         // 6-21 : Compression blocks count
         // 22   : Encrypted
         // 23-28: Compression method
-        // 29   : Size 32-bit safe?
-        // 30   : Uncompressed size 32-bit safe?
-        // 31   : Offset 32-bit safe?
+        // 29   : Size 32-bit
+        // 30   : Uncompressed size 32-bit
+        // 31   : Offset 32-bit
         decode!(reader, bitfield: u32);
         let compression_method = (bitfield >> 23) & 0x3f;
         let offset: u64;
@@ -273,7 +272,7 @@ impl Record {
             } else if compression_block_count > 0 {
                 let mut blocks = vec![];
                 let block_alignment = if encrypted {
-                    decrypt::BLOCK_SIZE as u64
+                    BLOCK_SIZE as u64
                 } else {
                     1
                 };

--- a/tests/unpack_v11_it.rs
+++ b/tests/unpack_v11_it.rs
@@ -3,6 +3,8 @@ mod util;
 use util::remove_dir_all_if_exists;
 use u4pak::Result;
 
+const ENCRYPTION_KEY: &str = "aWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWk=";
+
 #[test]
 fn test_v11() -> Result<()> {
     let out_dir = "./v11-it";
@@ -20,7 +22,7 @@ fn test_v11_encrypted() -> Result<()> {
     let out_dir = "./v11_encrypted-it";
     remove_dir_all_if_exists(out_dir)?;
 
-    util::unpack("./pak-examples/pak/v11/test_encrypted_v11.pak", out_dir, Some("aWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWk=".to_string()))?;
+    util::unpack("./pak-examples/pak/v11/test_encrypted_v11.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
     util::validate("./pak-examples/original-files", out_dir)?;
 
     remove_dir_all_if_exists(out_dir)?;
@@ -32,7 +34,7 @@ fn test_v11_encrypted_encindex() -> Result<()> {
     let out_dir = "./v11_encrypted_encindex-it";
     remove_dir_all_if_exists(out_dir)?;
 
-    util::unpack("./pak-examples/pak/v11/test_encrypted_encindex_v11.pak", out_dir, Some("aWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWk=".to_string()))?;
+    util::unpack("./pak-examples/pak/v11/test_encrypted_encindex_v11.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
     util::validate("./pak-examples/original-files", out_dir)?;
 
     remove_dir_all_if_exists(out_dir)?;
@@ -44,7 +46,7 @@ fn test_v11_encindex() -> Result<()> {
     let out_dir = "./v11_encindex-it";
     remove_dir_all_if_exists(out_dir)?;
 
-    util::unpack("./pak-examples/pak/v11/test_encindex_v11.pak", out_dir, Some("aWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWk=".to_string()))?;
+    util::unpack("./pak-examples/pak/v11/test_encindex_v11.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
     util::validate("./pak-examples/original-files", out_dir)?;
 
     remove_dir_all_if_exists(out_dir)?;
@@ -68,7 +70,7 @@ fn test_v11_compressed_encrypted() -> Result<()> {
     let out_dir = "./v11_compressed_encrypted-it";
     remove_dir_all_if_exists(out_dir)?;
 
-    util::unpack("./pak-examples/pak/v11/test_compressed_encrypted_v11.pak", out_dir, Some("aWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWk=".to_string()))?;
+    util::unpack("./pak-examples/pak/v11/test_compressed_encrypted_v11.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
     util::validate("./pak-examples/original-files", out_dir)?;
 
     remove_dir_all_if_exists(out_dir)?;
@@ -80,7 +82,7 @@ fn test_v11_compressed_encrypted_encindex() -> Result<()> {
     let out_dir = "./v11_compressed_encrypted_encindex-it";
     remove_dir_all_if_exists(out_dir)?;
 
-    util::unpack("./pak-examples/pak/v11/test_compressed_encrypted_encindex_v11.pak", out_dir, Some("aWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWk=".to_string()))?;
+    util::unpack("./pak-examples/pak/v11/test_compressed_encrypted_encindex_v11.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
     util::validate("./pak-examples/original-files", out_dir)?;
 
     remove_dir_all_if_exists(out_dir)?;
@@ -92,7 +94,7 @@ fn test_v11_compressed_encindex() -> Result<()> {
     let out_dir = "./v11_compressed_encindex-it";
     remove_dir_all_if_exists(out_dir)?;
 
-    util::unpack("./pak-examples/pak/v11/test_compressed_encindex_v11.pak", out_dir, Some("aWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWk=".to_string()))?;
+    util::unpack("./pak-examples/pak/v11/test_compressed_encindex_v11.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
     util::validate("./pak-examples/original-files", out_dir)?;
 
     remove_dir_all_if_exists(out_dir)?;

--- a/tests/unpack_v2_it.rs
+++ b/tests/unpack_v2_it.rs
@@ -1,0 +1,54 @@
+mod util;
+
+use u4pak::Result;
+use util::remove_dir_all_if_exists;
+
+const ENCRYPTION_KEY: &str = "aWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWk=";
+
+#[test]
+fn test_v3() -> Result<()> {
+    let out_dir = "./v3-it";
+    remove_dir_all_if_exists(out_dir)?;
+
+    util::unpack("./pak-examples/pak/v3/test_v3.pak", out_dir, None)?;
+    util::validate("./pak-examples/original-files", out_dir)?;
+
+    remove_dir_all_if_exists(out_dir)?;
+    Ok(())
+}
+
+#[test]
+fn test_v3_encrypted() -> Result<()> {
+    let out_dir = "./v3_encrypted-it";
+    remove_dir_all_if_exists(out_dir)?;
+
+    util::unpack("./pak-examples/pak/v3/test_encrypted_v3.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
+    util::validate("./pak-examples/original-files", out_dir)?;
+
+    remove_dir_all_if_exists(out_dir)?;
+    Ok(())
+}
+
+#[test]
+fn test_v3_compressed() -> Result<()> {
+    let out_dir = "./v3_compressed-it";
+    remove_dir_all_if_exists(out_dir)?;
+
+    util::unpack("./pak-examples/pak/v3/test_compressed_v3.pak", out_dir, None)?;
+    util::validate("./pak-examples/original-files", out_dir)?;
+
+    remove_dir_all_if_exists(out_dir)?;
+    Ok(())
+}
+
+#[test]
+fn test_v3_compressed_encrypted() -> Result<()> {
+    let out_dir = "./v3_compressed_encrypted-it";
+    remove_dir_all_if_exists(out_dir)?;
+
+    util::unpack("./pak-examples/pak/v3/test_compressed_encrypted_v3.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
+    util::validate("./pak-examples/original-files", out_dir)?;
+
+    remove_dir_all_if_exists(out_dir)?;
+    Ok(())
+}

--- a/tests/unpack_v3_it.rs
+++ b/tests/unpack_v3_it.rs
@@ -1,0 +1,54 @@
+mod util;
+
+use u4pak::Result;
+use util::remove_dir_all_if_exists;
+
+const ENCRYPTION_KEY: &str = "aWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWk=";
+
+#[test]
+fn test_v3() -> Result<()> {
+    let out_dir = "./v3-it";
+    remove_dir_all_if_exists(out_dir)?;
+
+    util::unpack("./pak-examples/pak/v3/test_v3.pak", out_dir, None)?;
+    util::validate("./pak-examples/original-files", out_dir)?;
+
+    remove_dir_all_if_exists(out_dir)?;
+    Ok(())
+}
+
+#[test]
+fn test_v3_encrypted() -> Result<()> {
+    let out_dir = "./v3_encrypted-it";
+    remove_dir_all_if_exists(out_dir)?;
+
+    util::unpack("./pak-examples/pak/v3/test_encrypted_v3.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
+    util::validate("./pak-examples/original-files", out_dir)?;
+
+    remove_dir_all_if_exists(out_dir)?;
+    Ok(())
+}
+
+#[test]
+fn test_v3_compressed() -> Result<()> {
+    let out_dir = "./v3_compressed-it";
+    remove_dir_all_if_exists(out_dir)?;
+
+    util::unpack("./pak-examples/pak/v3/test_compressed_v3.pak", out_dir, None)?;
+    util::validate("./pak-examples/original-files", out_dir)?;
+
+    remove_dir_all_if_exists(out_dir)?;
+    Ok(())
+}
+
+#[test]
+fn test_v3_compressed_encrypted() -> Result<()> {
+    let out_dir = "./v3_compressed_encrypted-it";
+    remove_dir_all_if_exists(out_dir)?;
+
+    util::unpack("./pak-examples/pak/v3/test_compressed_encrypted_v3.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
+    util::validate("./pak-examples/original-files", out_dir)?;
+
+    remove_dir_all_if_exists(out_dir)?;
+    Ok(())
+}

--- a/tests/unpack_v4_it.rs
+++ b/tests/unpack_v4_it.rs
@@ -1,0 +1,102 @@
+mod util;
+
+use u4pak::Result;
+use util::remove_dir_all_if_exists;
+
+const ENCRYPTION_KEY: &str = "aWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWk=";
+
+#[test]
+fn test_v4() -> Result<()> {
+    let out_dir = "./v4-it";
+    remove_dir_all_if_exists(out_dir)?;
+
+    util::unpack("./pak-examples/pak/v4/test_v4.pak", out_dir, None)?;
+    util::validate("./pak-examples/original-files", out_dir)?;
+
+    remove_dir_all_if_exists(out_dir)?;
+    Ok(())
+}
+
+#[test]
+fn test_v4_encrypted() -> Result<()> {
+    let out_dir = "./v4_encrypted-it";
+    remove_dir_all_if_exists(out_dir)?;
+
+    util::unpack("./pak-examples/pak/v4/test_encrypted_v4.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
+    util::validate("./pak-examples/original-files", out_dir)?;
+
+    remove_dir_all_if_exists(out_dir)?;
+    Ok(())
+}
+
+#[test]
+fn test_v4_encrypted_encindex() -> Result<()> {
+    let out_dir = "./v4_encrypted_encindex-it";
+    remove_dir_all_if_exists(out_dir)?;
+
+    util::unpack("./pak-examples/pak/v4/test_encrypted_encindex_v4.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
+    util::validate("./pak-examples/original-files", out_dir)?;
+
+    remove_dir_all_if_exists(out_dir)?;
+    Ok(())
+}
+
+#[test]
+fn test_v4_encindex() -> Result<()> {
+    let out_dir = "./v4_encindex-it";
+    remove_dir_all_if_exists(out_dir)?;
+
+    util::unpack("./pak-examples/pak/v4/test_encindex_v4.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
+    util::validate("./pak-examples/original-files", out_dir)?;
+
+    remove_dir_all_if_exists(out_dir)?;
+    Ok(())
+}
+
+#[test]
+fn test_v4_compressed() -> Result<()> {
+    let out_dir = "./v4_compressed-it";
+    remove_dir_all_if_exists(out_dir)?;
+
+    util::unpack("./pak-examples/pak/v4/test_compressed_v4.pak", out_dir, None)?;
+    util::validate("./pak-examples/original-files", out_dir)?;
+
+    remove_dir_all_if_exists(out_dir)?;
+    Ok(())
+}
+
+#[test]
+fn test_v4_compressed_encrypted() -> Result<()> {
+    let out_dir = "./v4_compressed_encrypted-it";
+    remove_dir_all_if_exists(out_dir)?;
+
+    util::unpack("./pak-examples/pak/v4/test_compressed_encrypted_v4.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
+    util::validate("./pak-examples/original-files", out_dir)?;
+
+    remove_dir_all_if_exists(out_dir)?;
+    Ok(())
+}
+
+#[test]
+fn test_v4_compressed_encrypted_encindex() -> Result<()> {
+    let out_dir = "./v4_compressed_encrypted_encindex-it";
+    remove_dir_all_if_exists(out_dir)?;
+
+    util::unpack("./pak-examples/pak/v4/test_compressed_encrypted_encindex_v4.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
+    util::validate("./pak-examples/original-files", out_dir)?;
+
+    remove_dir_all_if_exists(out_dir)?;
+    Ok(())
+}
+
+#[test]
+fn test_v4_compressed_encindex() -> Result<()> {
+    let out_dir = "./v4_compressed_encindex-it";
+    remove_dir_all_if_exists(out_dir)?;
+
+    util::unpack("./pak-examples/pak/v4/test_compressed_encindex_v4.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
+    util::validate("./pak-examples/original-files", out_dir)?;
+
+    remove_dir_all_if_exists(out_dir)?;
+    Ok(())
+}

--- a/tests/unpack_v5_it.rs
+++ b/tests/unpack_v5_it.rs
@@ -3,6 +3,8 @@ mod util;
 use u4pak::Result;
 use util::remove_dir_all_if_exists;
 
+const ENCRYPTION_KEY: &str = "aWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWk=";
+
 #[test]
 fn test_v5() -> Result<()> {
     let out_dir = "./v5-it";
@@ -20,7 +22,7 @@ fn test_v5_encrypted() -> Result<()> {
     let out_dir = "./v5_encrypted-it";
     remove_dir_all_if_exists(out_dir)?;
 
-    util::unpack("./pak-examples/pak/v5/test_encrypted_v5.pak", out_dir, Some("aWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWk=".to_string()))?;
+    util::unpack("./pak-examples/pak/v5/test_encrypted_v5.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
     util::validate("./pak-examples/original-files", out_dir)?;
 
     remove_dir_all_if_exists(out_dir)?;
@@ -32,7 +34,7 @@ fn test_v5_encrypted_encindex() -> Result<()> {
     let out_dir = "./v5_encrypted_encindex-it";
     remove_dir_all_if_exists(out_dir)?;
 
-    util::unpack("./pak-examples/pak/v5/test_encrypted_encindex_v5.pak", out_dir, Some("aWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWk=".to_string()))?;
+    util::unpack("./pak-examples/pak/v5/test_encrypted_encindex_v5.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
     util::validate("./pak-examples/original-files", out_dir)?;
 
     remove_dir_all_if_exists(out_dir)?;
@@ -44,7 +46,7 @@ fn test_v5_encindex() -> Result<()> {
     let out_dir = "./v5_encindex-it";
     remove_dir_all_if_exists(out_dir)?;
 
-    util::unpack("./pak-examples/pak/v5/test_encindex_v5.pak", out_dir, Some("aWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWk=".to_string()))?;
+    util::unpack("./pak-examples/pak/v5/test_encindex_v5.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
     util::validate("./pak-examples/original-files", out_dir)?;
 
     remove_dir_all_if_exists(out_dir)?;
@@ -68,7 +70,7 @@ fn test_v5_compressed_encrypted() -> Result<()> {
     let out_dir = "./v5_compressed_encrypted-it";
     remove_dir_all_if_exists(out_dir)?;
 
-    util::unpack("./pak-examples/pak/v5/test_compressed_encrypted_v5.pak", out_dir, Some("aWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWk=".to_string()))?;
+    util::unpack("./pak-examples/pak/v5/test_compressed_encrypted_v5.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
     util::validate("./pak-examples/original-files", out_dir)?;
 
     remove_dir_all_if_exists(out_dir)?;
@@ -80,7 +82,7 @@ fn test_v5_compressed_encrypted_encindex() -> Result<()> {
     let out_dir = "./v5_compressed_encrypted_encindex-it";
     remove_dir_all_if_exists(out_dir)?;
 
-    util::unpack("./pak-examples/pak/v5/test_compressed_encrypted_encindex_v5.pak", out_dir, Some("aWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWk=".to_string()))?;
+    util::unpack("./pak-examples/pak/v5/test_compressed_encrypted_encindex_v5.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
     util::validate("./pak-examples/original-files", out_dir)?;
 
     remove_dir_all_if_exists(out_dir)?;
@@ -92,7 +94,7 @@ fn test_v5_compressed_encindex() -> Result<()> {
     let out_dir = "./v5_compressed_encindex-it";
     remove_dir_all_if_exists(out_dir)?;
 
-    util::unpack("./pak-examples/pak/v5/test_compressed_encindex_v5.pak", out_dir, Some("aWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWk=".to_string()))?;
+    util::unpack("./pak-examples/pak/v5/test_compressed_encindex_v5.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
     util::validate("./pak-examples/original-files", out_dir)?;
 
     remove_dir_all_if_exists(out_dir)?;

--- a/tests/unpack_v7_it.rs
+++ b/tests/unpack_v7_it.rs
@@ -3,6 +3,8 @@ mod util;
 use util::remove_dir_all_if_exists;
 use u4pak::Result;
 
+const ENCRYPTION_KEY: &str = "aWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWk=";
+
 #[test]
 fn test_v7() -> Result<()> {
     let out_dir = "./v7-it";
@@ -20,7 +22,7 @@ fn test_v7_encrypted() -> Result<()> {
     let out_dir = "./v7_encrypted-it";
     remove_dir_all_if_exists(out_dir)?;
 
-    util::unpack("./pak-examples/pak/v7/test_encrypted_v7.pak", out_dir, Some("aWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWk=".to_string()))?;
+    util::unpack("./pak-examples/pak/v7/test_encrypted_v7.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
     util::validate("./pak-examples/original-files", out_dir)?;
 
     remove_dir_all_if_exists(out_dir)?;
@@ -32,7 +34,7 @@ fn test_v7_encrypted_encindex() -> Result<()> {
     let out_dir = "./v7_encrypted_encindex-it";
     remove_dir_all_if_exists(out_dir)?;
 
-    util::unpack("./pak-examples/pak/v7/test_encrypted_encindex_v7.pak", out_dir, Some("aWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWk=".to_string()))?;
+    util::unpack("./pak-examples/pak/v7/test_encrypted_encindex_v7.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
     util::validate("./pak-examples/original-files", out_dir)?;
 
     remove_dir_all_if_exists(out_dir)?;
@@ -44,7 +46,7 @@ fn test_v7_encindex() -> Result<()> {
     let out_dir = "./v7_encindex-it";
     remove_dir_all_if_exists(out_dir)?;
 
-    util::unpack("./pak-examples/pak/v7/test_encindex_v7.pak", out_dir, Some("aWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWk=".to_string()))?;
+    util::unpack("./pak-examples/pak/v7/test_encindex_v7.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
     util::validate("./pak-examples/original-files", out_dir)?;
 
     remove_dir_all_if_exists(out_dir)?;
@@ -68,7 +70,7 @@ fn test_v7_compressed_encrypted() -> Result<()> {
     let out_dir = "./v7_compressed_encrypted-it";
     remove_dir_all_if_exists(out_dir)?;
 
-    util::unpack("./pak-examples/pak/v7/test_compressed_encrypted_v7.pak", out_dir, Some("aWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWk=".to_string()))?;
+    util::unpack("./pak-examples/pak/v7/test_compressed_encrypted_v7.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
     util::validate("./pak-examples/original-files", out_dir)?;
 
     remove_dir_all_if_exists(out_dir)?;
@@ -80,7 +82,7 @@ fn test_v7_compressed_encrypted_encindex() -> Result<()> {
     let out_dir = "./v7_compressed_encrypted_encindex-it";
     remove_dir_all_if_exists(out_dir)?;
 
-    util::unpack("./pak-examples/pak/v7/test_compressed_encrypted_encindex_v7.pak", out_dir, Some("aWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWk=".to_string()))?;
+    util::unpack("./pak-examples/pak/v7/test_compressed_encrypted_encindex_v7.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
     util::validate("./pak-examples/original-files", out_dir)?;
 
     remove_dir_all_if_exists(out_dir)?;
@@ -92,7 +94,7 @@ fn test_v7_compressed_encindex() -> Result<()> {
     let out_dir = "./v7_compressed_encindex-it";
     remove_dir_all_if_exists(out_dir)?;
 
-    util::unpack("./pak-examples/pak/v7/test_compressed_encindex_v7.pak", out_dir, Some("aWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWk=".to_string()))?;
+    util::unpack("./pak-examples/pak/v7/test_compressed_encindex_v7.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
     util::validate("./pak-examples/original-files", out_dir)?;
 
     remove_dir_all_if_exists(out_dir)?;

--- a/tests/unpack_v8_it.rs
+++ b/tests/unpack_v8_it.rs
@@ -3,6 +3,8 @@ mod util;
 use util::remove_dir_all_if_exists;
 use u4pak::Result;
 
+const ENCRYPTION_KEY: &str = "aWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWk=";
+
 #[test]
 fn test_v8() -> Result<()> {
     let out_dir = "./v8-it";
@@ -20,7 +22,7 @@ fn test_v8_encrypted() -> Result<()> {
     let out_dir = "./v8_encrypted-it";
     remove_dir_all_if_exists(out_dir)?;
 
-    util::unpack("./pak-examples/pak/v8/test_encrypted_v8.pak", out_dir, Some("aWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWk=".to_string()))?;
+    util::unpack("./pak-examples/pak/v8/test_encrypted_v8.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
     util::validate("./pak-examples/original-files", out_dir)?;
 
     remove_dir_all_if_exists(out_dir)?;
@@ -32,7 +34,7 @@ fn test_v8_encrypted_encindex() -> Result<()> {
     let out_dir = "./v8_encrypted_encindex-it";
     remove_dir_all_if_exists(out_dir)?;
 
-    util::unpack("./pak-examples/pak/v8/test_encrypted_encindex_v8.pak", out_dir, Some("aWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWk=".to_string()))?;
+    util::unpack("./pak-examples/pak/v8/test_encrypted_encindex_v8.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
     util::validate("./pak-examples/original-files", out_dir)?;
 
     remove_dir_all_if_exists(out_dir)?;
@@ -44,7 +46,7 @@ fn test_v8_encindex() -> Result<()> {
     let out_dir = "./v8_encindex-it";
     remove_dir_all_if_exists(out_dir)?;
 
-    util::unpack("./pak-examples/pak/v8/test_encindex_v8.pak", out_dir, Some("aWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWk=".to_string()))?;
+    util::unpack("./pak-examples/pak/v8/test_encindex_v8.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
     util::validate("./pak-examples/original-files", out_dir)?;
 
     remove_dir_all_if_exists(out_dir)?;
@@ -68,7 +70,7 @@ fn test_v8_compressed_encrypted() -> Result<()> {
     let out_dir = "./v8_compressed_encrypted-it";
     remove_dir_all_if_exists(out_dir)?;
 
-    util::unpack("./pak-examples/pak/v8/test_compressed_encrypted_v8.pak", out_dir, Some("aWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWk=".to_string()))?;
+    util::unpack("./pak-examples/pak/v8/test_compressed_encrypted_v8.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
     util::validate("./pak-examples/original-files", out_dir)?;
 
     remove_dir_all_if_exists(out_dir)?;
@@ -80,7 +82,7 @@ fn test_v8_compressed_encrypted_encindex() -> Result<()> {
     let out_dir = "./v8_compressed_encrypted_encindex-it";
     remove_dir_all_if_exists(out_dir)?;
 
-    util::unpack("./pak-examples/pak/v8/test_compressed_encrypted_encindex_v8.pak", out_dir, Some("aWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWk=".to_string()))?;
+    util::unpack("./pak-examples/pak/v8/test_compressed_encrypted_encindex_v8.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
     util::validate("./pak-examples/original-files", out_dir)?;
 
     remove_dir_all_if_exists(out_dir)?;
@@ -92,7 +94,7 @@ fn test_v8_compressed_encindex() -> Result<()> {
     let out_dir = "./v8_compressed_encindex-it";
     remove_dir_all_if_exists(out_dir)?;
 
-    util::unpack("./pak-examples/pak/v8/test_compressed_encindex_v8.pak", out_dir, Some("aWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWk=".to_string()))?;
+    util::unpack("./pak-examples/pak/v8/test_compressed_encindex_v8.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
     util::validate("./pak-examples/original-files", out_dir)?;
 
     remove_dir_all_if_exists(out_dir)?;

--- a/tests/unpack_v9_it.rs
+++ b/tests/unpack_v9_it.rs
@@ -3,6 +3,8 @@ mod util;
 use util::remove_dir_all_if_exists;
 use u4pak::Result;
 
+const ENCRYPTION_KEY: &str = "aWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWk=";
+
 #[test]
 fn test_v9() -> Result<()> {
     let out_dir = "./v9-it";
@@ -20,7 +22,7 @@ fn test_v9_encrypted() -> Result<()> {
     let out_dir = "./v9_encrypted-it";
     remove_dir_all_if_exists(out_dir)?;
 
-    util::unpack("./pak-examples/pak/v9/test_encrypted_v9.pak", out_dir, Some("aWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWk=".to_string()))?;
+    util::unpack("./pak-examples/pak/v9/test_encrypted_v9.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
     util::validate("./pak-examples/original-files", out_dir)?;
 
     remove_dir_all_if_exists(out_dir)?;
@@ -32,7 +34,7 @@ fn test_v9_encrypted_encindex() -> Result<()> {
     let out_dir = "./v9_encrypted_encindex-it";
     remove_dir_all_if_exists(out_dir)?;
 
-    util::unpack("./pak-examples/pak/v9/test_encrypted_encindex_v9.pak", out_dir, Some("aWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWk=".to_string()))?;
+    util::unpack("./pak-examples/pak/v9/test_encrypted_encindex_v9.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
     util::validate("./pak-examples/original-files", out_dir)?;
 
     remove_dir_all_if_exists(out_dir)?;
@@ -44,7 +46,7 @@ fn test_v9_encindex() -> Result<()> {
     let out_dir = "./v9_encindex-it";
     remove_dir_all_if_exists(out_dir)?;
 
-    util::unpack("./pak-examples/pak/v9/test_encindex_v9.pak", out_dir, Some("aWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWk=".to_string()))?;
+    util::unpack("./pak-examples/pak/v9/test_encindex_v9.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
     util::validate("./pak-examples/original-files", out_dir)?;
 
     remove_dir_all_if_exists(out_dir)?;
@@ -68,7 +70,7 @@ fn test_v9_compressed_encrypted() -> Result<()> {
     let out_dir = "./v9_compressed_encrypted-it";
     remove_dir_all_if_exists(out_dir)?;
 
-    util::unpack("./pak-examples/pak/v9/test_compressed_encrypted_v9.pak", out_dir, Some("aWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWk=".to_string()))?;
+    util::unpack("./pak-examples/pak/v9/test_compressed_encrypted_v9.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
     util::validate("./pak-examples/original-files", out_dir)?;
 
     remove_dir_all_if_exists(out_dir)?;
@@ -80,7 +82,7 @@ fn test_v9_compressed_encrypted_encindex() -> Result<()> {
     let out_dir = "./v9_compressed_encrypted_encindex-it";
     remove_dir_all_if_exists(out_dir)?;
 
-    util::unpack("./pak-examples/pak/v9/test_compressed_encrypted_encindex_v9.pak", out_dir, Some("aWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWk=".to_string()))?;
+    util::unpack("./pak-examples/pak/v9/test_compressed_encrypted_encindex_v9.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
     util::validate("./pak-examples/original-files", out_dir)?;
 
     remove_dir_all_if_exists(out_dir)?;
@@ -92,7 +94,7 @@ fn test_v9_compressed_encindex() -> Result<()> {
     let out_dir = "./v9_compressed_encindex-it";
     remove_dir_all_if_exists(out_dir)?;
 
-    util::unpack("./pak-examples/pak/v9/test_compressed_encindex_v9.pak", out_dir, Some("aWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWk=".to_string()))?;
+    util::unpack("./pak-examples/pak/v9/test_compressed_encindex_v9.pak", out_dir, Some(ENCRYPTION_KEY.to_string()))?;
     util::validate("./pak-examples/original-files", out_dir)?;
 
     remove_dir_all_if_exists(out_dir)?;


### PR DESCRIPTION
Added unit tests and fixed some issues for v2 - v4 pak files:

- Added support for relative compression offset
- Fixed headersize >= v3
- Fixed the example file encryption key
- Using build in constant for encryption block size

Relates to #12 
Closes #27